### PR TITLE
Revert "Bump django-axes from 5.10.0 to 5.12.0"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ cryptography==3.3.1
 decorator==4.4.2
 Django==3.1.5
 django-anymail==8.1
-django-axes==5.12.0
+django-axes==5.10.0
 django-behaviors==0.5.1
 django-bulk-update==2.2.0
 django-cors-headers==3.6.0


### PR DESCRIPTION
Reverts f213/education-backend#118